### PR TITLE
Update version comment header (1.0.4)

### DIFF
--- a/disable-comments.php
+++ b/disable-comments.php
@@ -4,7 +4,7 @@
  * @wordpress-plugin
  * Plugin Name: Inpsyde Disable Comments
  * Description: Entirely ditches comments as a WordPress feature.
- * Version: 1.0.3
+ * Version: 1.0.4
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Update URI: false


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (N/A — metadata-only change, no code touched)
- [ ] Docs have been added/updated (N/A)

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix (version metadata correction). Version 1.0.4 was tagged without updating the plugin comment header in `disable-comments.php`.

## What is the current behavior? (You can also link to an open issue here)

Version 1.0.4 still gets identified by WordPress as 1.0.3, which is flagged as vulnerable ([WPScan report](https://wpscan.com/vulnerability/9d031532-6c54-4a16-bc6e-656761c9cde6/)). Security scanners report a false positive on sites that are actually running the patched code.

## What is the new behavior (if this is a feature change)?

Comment header updated to reflect 1.0.4, so WordPress and security scanners correctly identify the installed version.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No code changes, but the existing 1.0.4 tag would need to be re-tagged to include this fix. If re-tagging isn't an option, I can update this PR to bump the version to 1.0.5 instead.

## Security impact

**What changed (security perspective):**
No functional code changed — only the version string in the plugin comment header. This fixes version misreporting: the patched 1.0.4 release was self-identifying as 1.0.3, causing WPScan and similar tools to flag it as vulnerable. Correct reporting lets users and scanners verify they're on the patched release.

**Testing done:**
Confirmed the plugin now shows 1.0.4 in the WordPress admin Plugins page; diff verified as a single-line change.

**Residual risk (link Jira if any):**
Sites that already installed the mislabeled 1.0.4 will keep reporting as 1.0.3 until they update to the corrected release (re-tagged 1.0.4 or 1.0.5). No Jira ticket.

## Other information

Full diff is one line:

```php
 * Version: 1.0.4
```
